### PR TITLE
Fix to files extension

### DIFF
--- a/beep_downloader/download.py
+++ b/beep_downloader/download.py
@@ -38,7 +38,7 @@ def _do_download(url, path, cookies, ui):
                               res.headers["Content-Disposition"])
             if match:
                 filename = match.group(1)
-                ext = filename.rsplit(".")[1]
+                ext = filename.split(".")[-1]
                 if not path.endswith(ext):
                     path = path + "." + ext
         dirname = os.path.dirname(path)


### PR DESCRIPTION
If the filename had dots in it, the extension was not recognized correctly.